### PR TITLE
Fix suggestions

### DIFF
--- a/src/mocks/classes/Suggestions.ts
+++ b/src/mocks/classes/Suggestions.ts
@@ -5,6 +5,11 @@ export interface Suggestions extends BaseClassData {
 }
 
 export class Suggestions extends BaseClass<Suggestions> {
+  constructor() {
+    super();
+    this._data.suggestions = [];
+  }
+
   addSuggestions(suggestions: string[]) {
     suggestions.forEach(s => {
       this.addSuggestion(s);


### PR DESCRIPTION
Fix pushing suggestion to non-existing `_data.suggestions` property:

```
TypeError: Cannot read property 'push' of undefined
```